### PR TITLE
Set `continue-on-error: true` for pasting links into PR comments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,7 @@ runs:
     - name: Paste document download link into pull request
       uses: actions/github-script@v7
       if: github.event_name == 'pull_request'
+      continue-on-error: true
       with:
         github-token: ${{ inputs.github_token }}
         script: |


### PR DESCRIPTION
This makes sure that the status check of a PR does not fail when merging across forks.